### PR TITLE
Preserve packet+burst boundaries

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,8 @@
+Release 0.3.1 (pending)
+==========================
+
+- Preserve packet+burst boundaries in server readStream() endpoint
+
 Release 0.3.0 (2016-07-10)
 ==========================
 


### PR DESCRIPTION
Do not allow the server readStream() endpoint
to mix a second readStream() into the buffer
when the flags indicate that the last read
was an end of burst or single packet mode.
